### PR TITLE
[1주차 과제] TDD로 개발하기 > 기본과제

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/lock/LockManager.kt
+++ b/src/main/kotlin/io/hhplus/tdd/lock/LockManager.kt
@@ -1,0 +1,18 @@
+package io.hhplus.tdd.lock
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+class LockManager {
+
+    private val lockMap = ConcurrentHashMap<Long, ReentrantLock>()
+
+    fun <T> withLock(id: Long, block: () -> T): T {
+        val lock = lockMap.computeIfAbsent(id) { ReentrantLock(true) }
+
+        lock.withLock {
+            return block()
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/UserPoint.kt
@@ -5,6 +5,11 @@ data class UserPoint(
     val point: Long,
     val updateMillis: Long,
 ) {
+    init {
+        require(point >= 0) { "포인트 잔고가 부족합니다." }
+        require(point <= 10_000_000) { "최대 잔고는 10,000,000 포인트 입니다." }
+    }
+
     fun chargePoint(amount: Long): UserPoint {
         return UserPoint(id = id, point = point + amount, updateMillis = updateMillis)
     }

--- a/src/test/kotlin/io/hhplus/tdd/impl/PointHistoryRepositoryImplIT.kt
+++ b/src/test/kotlin/io/hhplus/tdd/impl/PointHistoryRepositoryImplIT.kt
@@ -17,6 +17,7 @@ class PointHistoryRepositoryImplIT {
         pointHistoryRepositoryImpl = PointHistoryRepositoryImpl(pointHistoryTable)
     }
 
+    // 포인트 내역 저장 Repository 통합 테스트
     @Test
     fun `포인트 충전, 이용 내역을 저장할 수 있다`() {
         // when
@@ -28,6 +29,7 @@ class PointHistoryRepositoryImplIT {
         assertThat(savedHistories[0]).isEqualTo(result)
     }
 
+    // 포인트 내역 조회 Repository 통합 테스트
     @Test
     fun `회원의 포인트 충전, 이용 내역을 조회할 수 있다`() {
         // given

--- a/src/test/kotlin/io/hhplus/tdd/impl/UserPointRepositoryImplIT.kt
+++ b/src/test/kotlin/io/hhplus/tdd/impl/UserPointRepositoryImplIT.kt
@@ -17,6 +17,7 @@ class UserPointRepositoryImplIT {
         userPointRepositoryImpl = UserPointRepositoryImpl(userPointTable)
     }
 
+    // 포인트 조회 Repository 통합 테스트
     @Test
     fun `포인트를 조회할 수 있다`() {
         // given
@@ -29,6 +30,7 @@ class UserPointRepositoryImplIT {
         assertThat(result).isEqualTo(savedPoint)
     }
 
+    // 포인트 저장 Repository 통합 테스트
     @Test
     fun `포인트를 저장할 수 있다`() {
         // when

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -21,6 +21,7 @@ class PointControllerTest {
     @MockBean
     private lateinit var pointService: PointService
 
+    // 포인트 조회 API 단위 테스트
     @Test
     fun point() {
         // given
@@ -36,6 +37,7 @@ class PointControllerTest {
             .andExpect(jsonPath("updateMillis").value(123L))
     }
 
+    // 포인트 내역 조회 API 단위 테스트
     @Test
     fun history() {
         // given
@@ -63,6 +65,7 @@ class PointControllerTest {
             .andExpect(jsonPath("[1].timeMillis").value(456L))
     }
 
+    // 포인트 충전 API 단위 테스트
     @Test
     fun charge() {
         // given
@@ -80,6 +83,7 @@ class PointControllerTest {
             .andExpect(jsonPath("updateMillis").value(123L))
     }
 
+    // 포인트 사용 API 단위 테스트
     @Test
     fun use() {
         // given

--- a/src/test/kotlin/io/hhplus/tdd/point/PointReaderTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointReaderTest.kt
@@ -19,6 +19,7 @@ class PointReaderTest {
         pointReader = PointReader(userPointRepository, pointHistoryRepository)
     }
 
+    // 포인트 조회 Component 단위 테스트
     @Test
     fun `포인트를 조회할 수 있다`() {
         // given
@@ -31,6 +32,7 @@ class PointReaderTest {
         assertThat(result).isEqualTo(savedPoint)
     }
 
+    // 포인트 내역 조회 Component 단위 테스트
     @Test
     fun `회원의 포인트 충전, 이용 내역을 조회할 수 있다`() {
         // given

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyIT.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyIT.kt
@@ -15,6 +15,7 @@ class PointServiceConcurrencyIT {
     @Autowired
     private lateinit var pointService: PointService
 
+    // 포인트 충전 동시성 테스트
     @Test
     fun `동일한 사용자의 포인트 충전 요청이 동시에 들어온 경우 정합성을 보장할 수 있다`() {
         // when
@@ -27,6 +28,7 @@ class PointServiceConcurrencyIT {
         assertThat(result.point).isEqualTo(1000L)
     }
 
+    // 포인트 사용 동시성 테스트
     @Test
     fun `동일한 사용자의 포인트 사용 요청이 동시에 들어온 경우 정합성을 보장할 수 있다`() {
         // given
@@ -42,6 +44,7 @@ class PointServiceConcurrencyIT {
         assertThat(result.point).isEqualTo(0L)
     }
 
+    // 포인트 충전, 사용 혼합 동시성 테스트
     @Test
     fun `동일한 사용자의 포인트 충전, 사용 요청이 동시에 들어온 경우 정합성을 보장할 수 있다`() {
         // given

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyIT.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceConcurrencyIT.kt
@@ -1,0 +1,58 @@
+package io.hhplus.tdd.point
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class PointServiceConcurrencyIT {
+
+    @Autowired
+    private lateinit var pointService: PointService
+
+    @Test
+    fun `동일한 사용자의 포인트 충전 요청이 동시에 들어온 경우 정합성을 보장할 수 있다`() {
+        // when
+        concurrencyTestHelper(10) {
+            pointService.charge(1L, 100L)
+        }
+
+        // then
+        val result = pointService.getPoint(1L)
+        assertThat(result.point).isEqualTo(1000L)
+    }
+
+    @Test
+    fun `동일한 사용자의 포인트 사용 요청이 동시에 들어온 경우 정합성을 보장할 수 있다`() {
+        // given
+        pointService.charge(1L, 1000L)
+
+        // when
+        concurrencyTestHelper(10) {
+            pointService.use(1L, 100L)
+        }
+
+        // then
+        val result = pointService.getPoint(1L)
+        assertThat(result.point).isEqualTo(0L)
+    }
+
+    private fun concurrencyTestHelper(times: Int, task: Runnable) {
+        val executorService = Executors.newFixedThreadPool(times)
+        try {
+            val futures = mutableListOf<Future<*>>()
+            repeat(times) {
+                val future = executorService.submit(task)
+                futures.add(future)
+            }
+            futures.forEach { it.get() }
+        } finally {
+            executorService.shutdown()
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointServiceTest.kt
@@ -20,6 +20,7 @@ class PointServiceTest {
         pointService = PointService(pointReader, pointUpdater)
     }
 
+    // 포인트 조회 Service 단위 테스트
     @Test
     fun `포인트를 조회할 수 있다`() {
         // given
@@ -32,6 +33,7 @@ class PointServiceTest {
         assertThat(result.point).isEqualTo(100L)
     }
 
+    // 포인트 내역 조회 Service 단위 테스트
     @Test
     fun `포인트 충전, 이용 내역을 조회할 수 있다`() {
         // given
@@ -52,6 +54,7 @@ class PointServiceTest {
         assertThat(result[1].amount).isEqualTo(1000L)
     }
 
+    // 포인트 충전 Service 단위 테스트
     @Test
     fun `포인트를 충전할 수 있다`() {
         // given
@@ -65,6 +68,7 @@ class PointServiceTest {
         verify(pointUpdater).insertHistory(1L, 1100L, TransactionType.CHARGE, 123L)
     }
 
+    // 포인트 사용 Service 단위 테스트
     @Test
     fun `포인트를 사용할 수 있다`() {
         // given

--- a/src/test/kotlin/io/hhplus/tdd/point/PointUpdaterTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointUpdaterTest.kt
@@ -19,6 +19,7 @@ class PointUpdaterTest {
         pointUpdater = PointUpdater(userPointRepository, pointHistoryRepository)
     }
 
+    // 포인트 충전 Component 단위 테스트
     @Test
     fun `포인트를 충전할 수 있다`() {
         // given
@@ -32,6 +33,7 @@ class PointUpdaterTest {
         assertThat(result).isEqualTo(userPointRepository.getById(1L))
     }
 
+    // 포인트 사용 Component 단위 테스트
     @Test
     fun `포인트를 사용할 수 있다`() {
         // given
@@ -45,6 +47,7 @@ class PointUpdaterTest {
         assertThat(result).isEqualTo(userPointRepository.getById(1L))
     }
 
+    // 포인트 내역 저장 Component 단위 테스트
     @Test
     fun `포인트 충전 이력을 저장할 수 있다`() {
         // when

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -1,0 +1,90 @@
+package io.hhplus.tdd.point
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class UserPointTest {
+
+    @Test
+    fun `최대 10,000,000 포인트까지 생성할 수 있다`() {
+        // when
+        UserPoint(1L, 10_000_000L, 123L)
+    }
+
+    @Test
+    fun `최대 10,000,000 포인트까지 충전할 수 있다`() {
+        // given
+        val userPoint = UserPoint(1L, 9_000_000L, 123L)
+
+        // when
+        val result = userPoint.chargePoint(1_000_000L)
+
+        // then
+        assertThat(result.point).isEqualTo(10_000_000L)
+    }
+
+    @Test
+    fun `10,000,000 포인트를 초과하여 생성할 수 없다`() {
+        // when then
+        assertThatThrownBy({
+            UserPoint(1L, 10_000_001L, 123L)
+        })
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("최대 잔고는 10,000,000 포인트 입니다.")
+    }
+
+    @Test
+    fun `10,000,000 포인트를 초과하여 충전할 수 없다`() {
+        // given
+        val userPoint = UserPoint(1L, 9_000_000L, 123L)
+
+        // when then
+        assertThatThrownBy({
+            userPoint.chargePoint(1_000_001L)
+        })
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("최대 잔고는 10,000,000 포인트 입니다.")
+    }
+
+    @Test
+    fun `최소 0 포인트까지 생성될 수 있다`() {
+        // when
+        UserPoint(1L, 0L, 123L)
+    }
+
+    @Test
+    fun `최소 0 포인트가 될 때까지 사용할 수 있다`() {
+        // given
+        val userPoint = UserPoint(1L, 1000L, 123L)
+
+        // when
+        val result = userPoint.usePoint(1000L)
+
+        // then
+        assertThat(result.point).isEqualTo(0L)
+    }
+
+    @Test
+    fun `포인트가 0 미만으로 내려가도록 생성할 수 없다`() {
+        // when then
+        assertThatThrownBy({
+            UserPoint(1L, -1L, 123L)
+        })
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("포인트 잔고가 부족합니다.")
+    }
+
+    @Test
+    fun `포인트가 0 미만으로 내려가도록 사용할 수 없다`() {
+        // given
+        val userPoint = UserPoint(1L, 1000L, 123L)
+
+        // when then
+        assertThatThrownBy({
+            userPoint.usePoint(1001L)
+        })
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("포인트 잔고가 부족합니다.")
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/UserPointTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test
 
 class UserPointTest {
 
+    // UserPoint 생성 시 포인트 상한 경곗값 테스트
     @Test
     fun `최대 10,000,000 포인트까지 생성할 수 있다`() {
         // when
         UserPoint(1L, 10_000_000L, 123L)
     }
 
+    // UserPoint 충전 시 포인트 상한 경곗값 테스트
     @Test
     fun `최대 10,000,000 포인트까지 충전할 수 있다`() {
         // given
@@ -24,6 +26,7 @@ class UserPointTest {
         assertThat(result.point).isEqualTo(10_000_000L)
     }
 
+    // UserPoint 생성 시 포인트 상한 경곗값 초과 테스트
     @Test
     fun `10,000,000 포인트를 초과하여 생성할 수 없다`() {
         // when then
@@ -34,6 +37,7 @@ class UserPointTest {
             .hasMessage("최대 잔고는 10,000,000 포인트 입니다.")
     }
 
+    // UserPoint 충전 시 포인트 상한 경곗값 초과 테스트
     @Test
     fun `10,000,000 포인트를 초과하여 충전할 수 없다`() {
         // given
@@ -47,12 +51,14 @@ class UserPointTest {
             .hasMessage("최대 잔고는 10,000,000 포인트 입니다.")
     }
 
+    // UserPoint 생성 시 포인트 하한 경곗값 테스트
     @Test
     fun `최소 0 포인트까지 생성될 수 있다`() {
         // when
         UserPoint(1L, 0L, 123L)
     }
 
+    // UserPoint 사용 시 포인트 하한 경곗값 테스트
     @Test
     fun `최소 0 포인트가 될 때까지 사용할 수 있다`() {
         // given
@@ -65,6 +71,7 @@ class UserPointTest {
         assertThat(result.point).isEqualTo(0L)
     }
 
+    // UserPoint 생성 시 포인트 하한 경곗값 미만 테스트
     @Test
     fun `포인트가 0 미만으로 내려가도록 생성할 수 없다`() {
         // when then
@@ -75,6 +82,7 @@ class UserPointTest {
             .hasMessage("포인트 잔고가 부족합니다.")
     }
 
+    // UserPoint 사용 시 포인트 하한 경곗값 미만 테스트
     @Test
     fun `포인트가 0 미만으로 내려가도록 사용할 수 없다`() {
         // given


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- 포인트 충전, 사용에 대한 정책 추가 : [defc65d](https://github.com/psh10066/hhplus-tdd/commit/defc65decfeb8f171935130f3f5a58c62d2c9cf8)
- 동시에 여러 요청이 들어오더라도 한 번에 하나의 요청만 제어될 수 있도록 리팩토링, 동시성 제어 통합 테스트 작성 : [724828e](https://github.com/psh10066/hhplus-tdd/commit/724828e58f4d35c4ec7f8725d509171eeebe92a8)
- 동시성 제어 통합 테스트 > 테스트 케이스 추가 : [3a69bbd](https://github.com/psh10066/hhplus-tdd/commit/3a69bbd6dd71130ad277541ce76a1ee3cfcf26db)
- 과제 필수 사항 > 테스트 케이스 작성 이유 주석 추가 : [c0dbdd4](https://github.com/psh10066/hhplus-tdd/commit/c0dbdd4f40dc17fa0feaf0da0e876ee4abd80ef0)

---
### **리뷰 포인트(질문)**
- 현재 추가된 동시성 테스트의 테스트 케이스가 충분한지 확인 부탁드립니다.
  - 포인트 충전이나 사용 로직이 진행되고있는 도중 포인트 조회 요청을 하면 앞의 로직이 실행되는 것을 기다렸다가 끝난 후 조회가 잘 되는지 테스트하고 싶었는데, 이 부분은 어떻게 검증해야 할지 어려웠습니다.
    - lock 내에서 실행되는 메서드의 클래스들을 stub 객체로 만든 후 Thread.sleep()으로 실행 순서를 조정하면서 검증하는 방식 정도 떠오르긴 했는데, 좋은 방법이 아닌 것 같다는 생각이 들었습니다.
- ConcurrentHashMap에 id별로 item이 하나씩 생기면, 이후로는 remove되지 않아서 계속 메모리 공간을 차지하는 것때문에 걱정이 됩니다. 이 부분은 괜찮은 걸까요?
  - 아래와 같이 remove 로직을 구현하려고 했으나, 이것도 if문 내에 들어갔을 때 lock을 다음 스레드가 가져가면 동시성 이슈가 생길 것 같아 포기했습니다.
    ```kotlin
    if(!lock.isLocked && lock.hasQueuedThreads()) {
        // lock을 해제한 스레드가 여기에 도달했을 때 다음 스레드가 lock을 가져가면 실패
        lockMap.remove(id)
    }
    ```
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 매일 최소 3시간 이상 열심히 한 점
- 열심히 멘토링 청강하러 다닌 점
- 질문을 잘 활용한 점

### Problem
<!--개선이 필요한 점-->
- 잘 되지 않는 것을 억지로 어떻게든 시도하려다가 시간을 낭비한 점

### Try
<!-- 새롭게 시도할 점 -->
- 기존에 알고 있는 지식 말고도 더 좋은 방법이 있는지 공부해보기